### PR TITLE
Add dev container configuration

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,3 +1,3 @@
 FROM mcr.microsoft.com/devcontainers/go:1-1.21-bullseye
 
-RUN sudo apt update && sudo apt -y install libespeak-ng-dev
+RUN sudo apt update && sudo apt -y install libespeak-ng-dev ffmpeg

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,3 @@
+FROM mcr.microsoft.com/devcontainers/go:1-1.21-bullseye
+
+RUN sudo apt update && sudo apt -y install libespeak-ng-dev

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,18 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/go
+{
+	"name": "Go",
+	"build": {
+		"dockerfile": "Dockerfile"
+	},
+
+	// Configure tool-specific properties.
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"golang.go",
+				"ms-vsliveshare.vsliveshare"
+			]
+		}
+	}
+}

--- a/README.md
+++ b/README.md
@@ -12,3 +12,10 @@ Project Pipeline:
     - Write new timing to file
 - End processTask
 - Collect logs (buffer) and print to console
+
+## Development setup
+
+Install Docker, VS Code, and the dev containers extension for VS Code.
+Clone this repository with git and open it in VS Code
+There should be a prompt in the bottom right to 'Reopen in dev container'; click the button to confirm this action
+If this does not show up, press Ctrl-Shift-P to open the command pallette and search for 'Dev Containers: Reopen in Container'


### PR DESCRIPTION
Add dev container to allow developing around espeak-ng temporarily

This is a stop-gap solution until a more portable version of espeak-ng can be used