### PR TITLE
Install espeak-ng before running lint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,6 +20,9 @@ jobs:
           go-version: "1.21"
           cache: false
 
+      - name: Install espeak-ng
+        run: sudo apt-get install -y libespeak-ng-dev
+
       - name: golanci-lint
         uses: golangci/golangci-lint-action@v3
         with:


### PR DESCRIPTION
This makes it so that the Go code can compile after finding the appropriate dependencies